### PR TITLE
Separator improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
     config.load()
 
     application = QApplication(sys.argv)
+    application.setDoubleClickInterval(config.double_click_interval)
     config._native_style = application.style().name()
     if config.theme != "native":
         application.setStyle(config.theme)

--- a/source/core/config.py
+++ b/source/core/config.py
@@ -92,6 +92,7 @@ class _Config:
     preview_border: str = ""
     preview_bg: str = ""
     preview_bg_mode: str = "auto"
+    double_click_interval: int = 250
     _native_style: str = ""
 
 
@@ -273,6 +274,7 @@ def load() -> None:
         _cfg.preview_border = theme_section.get("preview_border", "")
         _cfg.preview_bg = theme_section.get("preview_bg", "")
         _cfg.preview_bg_mode = theme_section.get("preview_bg_mode", "auto")
+        _cfg.double_click_interval = settings_section.get("double_click_interval", 250)
         database.init()
     except FileNotFoundError:
         os.makedirs(paths.config_dir, exist_ok=True)
@@ -339,6 +341,7 @@ def _do_save() -> None:
                 "notifications_enabled": _v("notifications_enabled"),
                 "check_updates_on_startup": _v("check_updates_on_startup"),
                 "include_prereleases": _v("include_prereleases"),
+                "double_click_interval": _v("double_click_interval"),
             },
             "theme": {
                 "accent": _v("accent_color"),

--- a/source/ui/dialogs/separator.py
+++ b/source/ui/dialogs/separator.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from typing import Optional
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QColorDialog,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QLabel,
     QLineEdit,
     QPushButton,
+    QVBoxLayout,
     QWidget,
 )
 
@@ -22,14 +25,33 @@ class SeparatorDialog(QDialog):
         title: str,
         name: str = "",
         color: str = "",
+        existing_names: Optional[set[str]] = None,
+        allow_name: Optional[str] = None,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle(title)
+        # 350, 190
+        self.setMinimumSize(350, 130)
         self._color = color or config.separator_color
-        form_layout = QFormLayout(self)
+        self._existing_names = existing_names or set()
+        self._allow_name = allow_name
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(10, 10, 10, 6)
+        main_layout.setSpacing(6)
+
+        form_layout = QFormLayout()
+        form_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._warning_label = QLabel()
+        self._warning_label.setStyleSheet("color: #EAB308;")
+        self._warning_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self._warning_label.setText(" ")
+        self._warning_label.setMinimumHeight(self._warning_label.sizeHint().height())
 
         self.name_edit = QLineEdit(name)
+        self.name_edit.textChanged.connect(self._validate_name)
 
         self.color_btn = QPushButton()
         self.color_btn.setStyleSheet(
@@ -37,15 +59,31 @@ class SeparatorDialog(QDialog):
         )
         self.color_btn.clicked.connect(self._pick_color)
 
+        form_layout.addRow("", self._warning_label)
+        form_layout.addRow("Name:", self.name_edit)
+        form_layout.addRow("Color:", self.color_btn)
+
+        main_layout.addLayout(form_layout)
+        main_layout.addStretch()
+
         dialog_buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
+        self._ok_btn = dialog_buttons.button(QDialogButtonBox.StandardButton.Ok)
         dialog_buttons.accepted.connect(self.accept)
         dialog_buttons.rejected.connect(self.reject)
+        main_layout.addWidget(dialog_buttons)
 
-        form_layout.addRow("Name:", self.name_edit)
-        form_layout.addRow("Color:", self.color_btn)
-        form_layout.addRow(dialog_buttons)
+        self._validate_name(name)
+
+    def _validate_name(self, text: str) -> None:
+        name = text.strip()
+        if name and name in self._existing_names and name != self._allow_name:
+            self._warning_label.setText("\u26A0 A separator with this name already exists!")
+            self._ok_btn.setEnabled(False)
+        else:
+            self._warning_label.setText(" ")
+            self._ok_btn.setEnabled(True)
 
     def _pick_color(self) -> None:
         selected_color = QColorDialog.getColor(QColor(self._color), self)

--- a/source/ui/panels/console.py
+++ b/source/ui/panels/console.py
@@ -106,14 +106,16 @@ class ConsoleWidget(QWidget):
             cursor.movePosition(
                 QTextCursor.MoveOperation.EndOfBlock, QTextCursor.MoveMode.KeepAnchor
             )
+            cursor.movePosition(
+                QTextCursor.MoveOperation.NextBlock, QTextCursor.MoveMode.KeepAnchor
+            )
             cursor.removeSelectedText()
             self._insert_tag(cursor, prefix, tag_color)
             self._insert_timestamp(cursor, timestamp)
             msg_fmt = QTextCharFormat()
             if not self._native_theme and msg_color:
                 msg_fmt.setForeground(QColor(msg_color))
-            cursor.insertText(f"{message} x{self._repeat_count + 1}", msg_fmt)
-            cursor.insertText("\n")
+            cursor.insertText(f"{message} x{self._repeat_count + 1}\n", msg_fmt)
         else:
             self._last_message = current_key
             self._repeat_count = 0

--- a/source/ui/panels/mod_list.py
+++ b/source/ui/panels/mod_list.py
@@ -175,6 +175,7 @@ class ModListPanel(QWidget):
         self._undo_stack: list[list[str]] = []
         self._redo_stack: list[list[str]] = []
         self._folded_separators: set[str] = set()
+        self._pressed_folded_sep: tuple | None = None
         self._load_fold_state()
 
         layout = QVBoxLayout(self)
@@ -239,6 +240,7 @@ class ModListPanel(QWidget):
         self.settingsBtn.clicked.connect(self.open_settings.emit)
         self.listView.doubleClicked.connect(self._on_item_double_clicked)
         self.listView.clicked.connect(self._on_item_clicked)
+        self.listView.viewport().installEventFilter(self)
         self.listView.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.listView.customContextMenuRequested.connect(self._on_context_menu)
 
@@ -1224,6 +1226,24 @@ class ModListPanel(QWidget):
         self.mods_loaded.emit()
 
     def eventFilter(self, obj, event) -> bool:
+        if obj is self.listView.viewport():
+            if event.type() == QEvent.MouseButtonPress:
+                index = self.listView.indexAt(event.pos())
+                self._pressed_folded_sep = None
+                if index.isValid():
+                    col0 = self.model.item(index.row(), 0)
+                    if col0 and col0.data(SEPARATOR_ROLE):
+                        sep_data = col0.data(SEPARATOR_ROLE)
+                        if sep_data["name"] in self._folded_separators:
+                            self._pressed_folded_sep = (col0, event.pos())
+            elif event.type() == QEvent.MouseMove and self._pressed_folded_sep:
+                col0, press_pos = self._pressed_folded_sep
+                delta = event.pos() - press_pos
+                if abs(delta.x()) + abs(delta.y()) > QApplication.startDragDistance():
+                    self._pressed_folded_sep = None
+                    self._toggle_fold(col0)
+            elif event.type() in (QEvent.MouseButtonRelease, QEvent.MouseButtonDblClick):
+                self._pressed_folded_sep = None
         if obj is self.listView and event.type() == QEvent.KeyPress:
             if (
                 event.key() == Qt.Key_Z
@@ -1264,16 +1284,21 @@ class ModListPanel(QWidget):
             item_name = c0.text() if c0 else ""
             try:
                 shutil.rmtree(folder_path)
-                deleted.append(item_name)
+                deleted.append((c0.row(), item_name))
             except OSError as exc:
                 self.log_message.emit(
                     f"Deleting separator '{item_name}': {exc}", "error"
                 )
         if deleted:
-            self.log_message.emit(f"Deleted separators: {', '.join(deleted)}", "info")
+            for _, name in deleted:
+                self._folded_separators.discard(name)
+            self._save_fold_state()
+            for row, _ in sorted(deleted, key=lambda t: t[0], reverse=True):
+                self.model.removeRow(row)
+            names = [n for _, n in deleted]
+            self.log_message.emit(f"Deleted separators: {', '.join(names)}", "debug")
             self._save_current_order()
             self._push_history()
-            self.load_mod_list()
 
     def _on_item_double_clicked(self, index) -> None:
         col0 = self.model.item(index.row(), 0)
@@ -1310,10 +1335,13 @@ class ModListPanel(QWidget):
     def _edit_separator(self, col0) -> None:
         separator_data = col0.data(SEPARATOR_ROLE)
         old_separator_folder = col0.data(Qt.ItemDataRole.UserRole)
+        old_name = separator_data["name"]
         dialog = SeparatorDialog(
             "Edit Separator",
-            name=separator_data["name"],
+            name=old_name,
             color=separator_data["color"],
+            existing_names=self._existing_separator_names(),
+            allow_name=old_name,
             parent=self,
         )
         if dialog.exec() != QDialog.Accepted:
@@ -1342,10 +1370,31 @@ class ModListPanel(QWidget):
         ET.SubElement(xml_root, "color").text = new_separator_color
         xml_tree = ET.ElementTree(xml_root)
         xml_tree.write(separator_xml_path, encoding="utf-8", xml_declaration=True)
+
+        col0.setData(new_separator_folder, Qt.ItemDataRole.UserRole)
+        new_separator_data = {"name": new_separator_name, "color": new_separator_color}
+        col0.setData(new_separator_data, SEPARATOR_ROLE)
+        col0.setText(new_separator_name)
+        new_bg = QColor(new_separator_color)
+        col0.setBackground(new_bg)
+        col0.setForeground(text_color_for_bg(new_bg))
+        col0.setIcon(QIcon(self._get_fold_arrow_pixmap(
+            col0.data(FOLDED_ROLE), col0.foreground().color()
+        )))
+        for c in range(1, 4):
+            sibling = self.model.item(col0.row(), c)
+            if sibling:
+                sibling.setBackground(new_bg)
+
+        if old_name != new_separator_name:
+            if old_name in self._folded_separators:
+                self._folded_separators.discard(old_name)
+                self._folded_separators.add(new_separator_name)
+                self._save_fold_state()
+
         self.log_message.emit(f"Updated separator '{new_separator_name}'", "info")
         self._save_current_order()
         self._push_history()
-        self.load_mod_list()
 
     def _on_context_menu(self, position) -> None:
         index = self.listView.indexAt(position)
@@ -1387,7 +1436,7 @@ class ModListPanel(QWidget):
 
         if col0.data(SEPARATOR_ROLE):
             context_menu.addAction("Edit", lambda: self._edit_separator(col0))
-            context_menu.addAction("Delete", lambda: self._delete_separator(col0))
+            context_menu.addAction("Delete", lambda: self._delete_separators([col0]))
         else:
             submenu = QMenu("Change Separator", context_menu)
             submenu.setStyleSheet(context_menu.styleSheet())
@@ -1556,25 +1605,21 @@ class ModListPanel(QWidget):
         mod_path = os.path.join(config.mods_path, mod_folder)
         open_path(mod_path)
 
-    def _delete_separator(self, col0) -> None:
-        import shutil
-
-        separator_folder = col0.data(Qt.ItemDataRole.UserRole)
-        folder_path = os.path.join(config.mods_path, separator_folder)
-        item_name = col0.text() if col0 else ""
-        try:
-            shutil.rmtree(folder_path)
-            self.log_message.emit(f"Deleted separator '{item_name}'", "info")
-            self._save_current_order()
-            self._push_history()
-            self.load_mod_list()
-        except OSError as exception:
-            self.log_message.emit(f"Deleting separator: {exception}", "error")
+    def _existing_separator_names(self) -> set[str]:
+        names = set()
+        for row in range(self.model.rowCount()):
+            item = self.model.item(row, 0)
+            if item and item.data(SEPARATOR_ROLE):
+                names.add(item.text())
+        return names
 
     def _create_separator(self) -> None:
         from PySide6.QtWidgets import QDialog
 
-        dialog = SeparatorDialog("Create Separator", parent=self)
+        dialog = SeparatorDialog(
+            "Create Separator", existing_names=self._existing_separator_names(),
+            parent=self,
+        )
         if dialog.exec() != QDialog.Accepted:
             return
         separator_name = dialog.result_name
@@ -1595,9 +1640,32 @@ class ModListPanel(QWidget):
             self.log_message.emit(f"Created separator '{separator_name}'", "info")
         except OSError as exception:
             self.log_message.emit(f"Creating separator: {exception}", "error")
+
+        from PySide6.QtGui import QStandardItem
+        col0 = QStandardItem()
+        col1 = QStandardItem()
+        col2 = QStandardItem()
+        col3 = QStandardItem()
+        for item in (col1, col2, col3):
+            item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+        col0.setData(separator_folder, Qt.ItemDataRole.UserRole)
+        separator_data = {"name": separator_name, "color": separator_color}
+        col0.setData(separator_data, SEPARATOR_ROLE)
+        col0.setText(separator_name)
+        bg = QColor(separator_color)
+        col0.setBackground(bg)
+        col0.setForeground(text_color_for_bg(bg))
+        col0.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+        is_folded = separator_name in self._folded_separators
+        col0.setData(is_folded, FOLDED_ROLE)
+        col0.setIcon(QIcon(self._get_fold_arrow_pixmap(is_folded, col0.foreground().color())))
+        col1.setBackground(bg)
+        col2.setBackground(bg)
+        col3.setBackground(bg)
+        self.model.appendRow([col0, col1, col2, col3])
+
         self._save_current_order()
         self._push_history()
-        self.load_mod_list()
 
     def _create_separator_at_selection(self) -> None:
         from PySide6.QtWidgets import QDialog
@@ -1611,7 +1679,10 @@ class ModListPanel(QWidget):
         if not selected_item or selected_item.data(SEPARATOR_ROLE):
             return
 
-        dialog = SeparatorDialog("Create Separator", parent=self)
+        dialog = SeparatorDialog(
+            "Create Separator", existing_names=self._existing_separator_names(),
+            parent=self,
+        )
         if dialog.exec() != QDialog.Accepted:
             return
         separator_name = dialog.result_name

--- a/source/ui/panels/mod_list.py
+++ b/source/ui/panels/mod_list.py
@@ -1402,6 +1402,9 @@ class ModListPanel(QWidget):
                     sep_name, lambda s=sep_item: self._move_to_separator(s)
                 )
             context_menu.addMenu(submenu)
+            context_menu.addAction(
+                "Create Separator", lambda: self._create_separator_at_selection()
+            )
             context_menu.addSeparator()
             context_menu.addAction(
                 "Enable Selected", lambda: self._toggle_selected(True)
@@ -1595,6 +1598,70 @@ class ModListPanel(QWidget):
         self._save_current_order()
         self._push_history()
         self.load_mod_list()
+
+    def _create_separator_at_selection(self) -> None:
+        from PySide6.QtWidgets import QDialog
+
+        selected_indexes = self.listView.selectedIndexes()
+        if not selected_indexes:
+            return
+
+        first_idx = selected_indexes[0]
+        selected_item = self.model.item(first_idx.row(), 0)
+        if not selected_item or selected_item.data(SEPARATOR_ROLE):
+            return
+
+        dialog = SeparatorDialog("Create Separator", parent=self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        separator_name = dialog.result_name
+        separator_color = dialog.result_color
+        if not separator_name:
+            return
+
+        separator_folder = f"{separator_name}{SEPARATOR_SUFFIX}"
+        try:
+            os.makedirs(os.path.join(config.mods_path, separator_folder), exist_ok=True)
+            separator_xml_path = os.path.join(
+                config.mods_path, separator_folder, "separator.xml"
+            )
+            xml_root = ET.Element("separator")
+            ET.SubElement(xml_root, "name").text = separator_name
+            ET.SubElement(xml_root, "color").text = separator_color
+            xml_tree = ET.ElementTree(xml_root)
+            xml_tree.write(separator_xml_path, encoding="utf-8", xml_declaration=True)
+            self.log_message.emit(f"Created separator '{separator_name}'", "info")
+        except OSError as exception:
+            self.log_message.emit(f"Creating separator: {exception}", "error")
+
+        from PySide6.QtGui import QStandardItem
+        col0 = QStandardItem()
+        col1 = QStandardItem()
+        col2 = QStandardItem()
+        col3 = QStandardItem()
+        for item in (col1, col2, col3):
+            item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+        col0.setData(separator_folder, Qt.ItemDataRole.UserRole)
+        separator_data = {"name": separator_name, "color": separator_color}
+        col0.setData(separator_data, SEPARATOR_ROLE)
+        col0.setText(separator_name)
+        col0.setBackground(QColor(separator_color))
+        col0.setForeground(text_color_for_bg(QColor(separator_color)))
+        col0.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+        is_folded = separator_name in self._folded_separators
+        col0.setData(is_folded, FOLDED_ROLE)
+        fg_color = col0.foreground().color()
+        col0.setIcon(QIcon(self._get_fold_arrow_pixmap(is_folded, fg_color)))
+        bg = QColor(separator_color)
+        col1.setBackground(bg)
+        col2.setBackground(bg)
+        col3.setBackground(bg)
+
+        insert_row = first_idx.row() + 1
+        self.model.insertRow(insert_row, [col0, col1, col2, col3])
+
+        self._save_current_order()
+        self._push_history()
 
     def _export_modlist(self) -> None:
 


### PR DESCRIPTION
Added the option to create a separator below the actively selected mod
Added the option to send a mod to higher / lowest priority quickly
<img width="667" height="373" alt="image" src="https://github.com/user-attachments/assets/146f0989-529f-431a-b9cc-f9f36f2be959" />

This PR fixes: #25 & #27 